### PR TITLE
Add Squadrone system, Onet sécurité Telem & softathome description

### DIFF
--- a/societes/france.json
+++ b/societes/france.json
@@ -3158,7 +3158,7 @@
         {
             "name": "SoftAtHome",
             "url": "http://www.softathome.com",
-            "description": "",
+            "description": "Set-top box & home gateway",
             "locations": [
                 {
                     "name": "",

--- a/societes/france.json
+++ b/societes/france.json
@@ -2482,6 +2482,18 @@
                 }
             ]
         },
+	{
+            "name": "Onet securité Telem",
+            "url": "http://www.telemsa.com/",
+            "description": "Security systems",
+            "locations": [
+                {
+                    "name": "",
+                    "postal_address": "16, rue de l'Etang - ZI de Mayencin - 38610 Gières",
+                    "gps_coordinates": "45.18524/5.77883"
+                }
+            ]
+        },
         {
             "name": "OpenPattern",
             "url": "http://www.openpattern.com",

--- a/societes/france.json
+++ b/societes/france.json
@@ -2490,7 +2490,7 @@
                 {
                     "name": "",
                     "postal_address": "16, rue de l'Etang - ZI de Mayencin - 38610 Gières",
-                    "gps_coordinates": "45.18524/5.77883"
+                    "gps_coordinates": "45.18515/5.77920"
                 }
             ]
         },

--- a/societes/france.json
+++ b/societes/france.json
@@ -3167,6 +3167,18 @@
                 }
             ]
         },
+	{
+            "name": "Squadrone system",
+            "url": "http://squadrone-system.com",
+            "description": "Auto following systems for drones",
+            "locations": [
+                {
+                    "name": "",
+                    "postal_address": "1 place Firmin Gautier 38000 Grenoble - France",
+                    "gps_coordinates": "45.1904754/5.7121659"
+                }
+            ]
+	},
         {
             "name": "ST-Ericsson",
             "url": "http://www.stericsson.com",


### PR DESCRIPTION
à propos de Squadrone system, ils utilisent les locaux de Sogilis. J'ai vu qu'il y a un champ "name" dans location. Ça serait bien de pouvoir l'utiliser dans ce cas. Sauf qu'il prend la priorité sur le vrai nom dans la popup.